### PR TITLE
Add memcached

### DIFF
--- a/files/memcached/config.sls
+++ b/files/memcached/config.sls
@@ -1,0 +1,32 @@
+#!py
+import math
+
+def config():
+    states = {}
+
+    # give memcached 25% of memory
+    malloc = math.floor(__grains__['mem_total'] / 4)
+
+    # Ubuntu package creates memcache user, debian can use nobody - needs investigation
+    if __grains__['os'] == 'Debian':
+        user = 'nobody'
+    else:
+        user = 'memcache'
+
+    states['/etc/memcached.conf'] = {
+        'file.managed': [
+            {'source': 'salt://memcached/templates/memcached.conf'},
+            {'user': 'root'},
+            {'group': 'root'},
+            {'mode': 644},
+            {'template': 'jinja'},
+            {'context': { 
+                'malloc': malloc,
+                'user': user
+            }}
+        ]
+    }
+    return states
+
+def run():
+    return config()

--- a/files/memcached/init.sls
+++ b/files/memcached/init.sls
@@ -1,0 +1,12 @@
+include:
+    - memcached.config
+
+memcached:
+    pkg:
+        - installed
+    service.running:
+        - require:
+            - pkg: memcached
+            - sls: memcached.config
+        - watch:
+            - file: /etc/memcached.conf

--- a/files/memcached/templates/memcached.conf
+++ b/files/memcached/templates/memcached.conf
@@ -1,0 +1,7 @@
+-d
+logfile /var/log/memcached.log
+-m {{ malloc }}
+-p 11211
+-l 127.0.0.1
+-c 4096
+-u {{ user }}


### PR DESCRIPTION
- I wonder if the memcache user should just be predefined and
  standardized across distros -- 'memcache' as a user seems reasonable.
