### PR TITLE
Add letsencrypt certificate and pound SSL termination

### DIFF
--- a/files/nginx/config.sls
+++ b/files/nginx/config.sls
@@ -97,6 +97,15 @@ class Config():
         ]
         self.states[self.conf_dir + 'nginx.conf'] = {'file.managed': main_nginx_file_options}
 
+        self.states['/etc/nginx/ssl'] = {
+            'file.directory': [
+                {'user': 'root'},
+                {'group': 'root'},
+                {'mode': 700},
+                {'makedirs': True}
+            ]
+        }
+
         # ubuntu package includes this by default, debian, annoyingly does not
         if self.grains['os'] == 'Debian':
             line = 'fastcgi_param  SCRIPT_FILENAME    $document_root$fastcgi_script_name;'

--- a/files/nginx/templates/vhost
+++ b/files/nginx/templates/vhost
@@ -62,7 +62,7 @@ server {
 
 {% if ssl -%}
 server {
-    listen 443;
+    listen 8443;
     access_log  /var/log/nginx/{{ server_name }}.access.log combined;
     server_name  {{ server_name }};
     root    /var/www/{{ server_name }}/{{ sub_dir }};

--- a/files/pound/config.sls
+++ b/files/pound/config.sls
@@ -1,0 +1,45 @@
+#!py
+
+def config(states):
+    certs = []
+    public_ip = __grains__['fqdn_ip4'][0]
+    webroot_base = __pillar__['webroot_base'].rstrip("/")
+
+    # figure out if cert is defined or we default to the self-signed cert
+    for website, data in __pillar__['websites'].iteritems():
+        if 'ssl' in data and data['ssl']:
+            pem_path = '/etc/nginx/ssl/{0}.pem'.format(website)
+            certs.append(pem_path)
+
+    states['/etc/pound/pound.cfg'] = {
+        'file.managed': [
+            {'user': 'root'},
+            {'group': 'root'},
+            {'mode': 644},
+            {'makedirs': True},
+            {'template': 'jinja'},
+            {'source': 'salt://pound/templates/pound.cfg'},
+            {'context': {
+                'certs': certs,
+                'public_ip': public_ip
+            }},
+        ]
+    }
+
+    states['/etc/default/pound'] = {
+        'file.managed': [
+            {'user': 'root'},
+            {'group': 'root'},
+            {'mode': 644},
+            {'makedirs': True},
+            {'template': 'jinja'},
+            {'source': 'salt://pound/templates/default'}
+        ]
+    }
+    return states
+
+def run():
+    states = {}
+    states = config(states)
+    return states
+

--- a/files/pound/init.sls
+++ b/files/pound/init.sls
@@ -1,0 +1,13 @@
+include:
+    - pound.config
+
+pound:
+    pkg:
+        - installed
+    service.running:
+        - require:
+            - pkg: pound
+            - sls: pound.config
+        - watch:
+            - file: /etc/pound/pound.cfg
+

--- a/files/pound/templates/default
+++ b/files/pound/templates/default
@@ -1,0 +1,1 @@
+startup=1

--- a/files/pound/templates/pound.cfg
+++ b/files/pound/templates/pound.cfg
@@ -1,0 +1,37 @@
+User        "www-data"
+Group       "www-data"
+## Logging: (goes to syslog by default)
+##  0   no logging
+##  1   normal
+##  2   extended
+##  3   Apache-style (common log format)
+LogLevel    3
+
+## check backend every X secs:
+Alive       10
+
+Timeout     300
+
+## use hardware-accelleration card supported by openssl(1):
+#SSLEngine  "<hw>"
+
+# poundctl control socket
+Control "/var/run/pound/poundctl.socket"
+
+# Decrypt and pass it to varnish
+ListenHTTPS
+    Address 0.0.0.0
+    Port    443
+    {% for cert in certs %}
+    Cert "{{ cert }}"
+    {% endfor %}
+    HeadRemove "X-Forwarded-Proto"
+    AddHeader "X-Forwarded-Proto: https"
+    Service
+        BackEnd
+            Address 127.0.0.1
+            Port    80
+        End
+    End
+End
+

--- a/pillar/websites/init.sls
+++ b/pillar/websites/init.sls
@@ -11,7 +11,7 @@ websites:
     hamster-sweaters.com:
         aliases:
             - www.hamster-sweaters.com
-        ssl: False
+        ssl: True
         cms: False
         sub_dir: '_site'
     kevops.com:


### PR DESCRIPTION
- Pound requires a particular order for the .pem
  - key
  - cert
  - chain
- I thought that was pretty standard, but letsencrypt has it reversed
